### PR TITLE
Support for Rails 7.1

### DIFF
--- a/lib/yabeda/activejob.rb
+++ b/lib/yabeda/activejob.rb
@@ -96,7 +96,7 @@ module Yabeda
       enqueue_time = event.payload[:job].enqueued_at
       return nil unless enqueue_time.present?
 
-      enqueue_time = Time.parse(enqueue_time).utc
+      enqueue_time = Time.parse(enqueue_time).utc unless enqueue_time.is_a?(Time)
       perform_at_time = Time.parse(event.end.to_s).utc
       (perform_at_time - enqueue_time)
     end


### PR DESCRIPTION
`event.payload[:job].enqueued_at` is an instance of Time in Rails 7.1 which makes Time.parse fail. Fix it by parsing time only when is needed.

See https://github.com/rails/rails/pull/48066