### PR TITLE
Support event.end time in seconds

### DIFF
--- a/lib/yabeda/activejob.rb
+++ b/lib/yabeda/activejob.rb
@@ -96,13 +96,22 @@ module Yabeda
       enqueue_time = event.payload[:job].enqueued_at
       return nil unless enqueue_time.present?
 
-      enqueue_time = Time.parse(enqueue_time).utc unless enqueue_time.is_a?(Time)
-      perform_at_time = Time.parse(event.end.to_s).utc
-      (perform_at_time - enqueue_time)
+      enqueue_time = parse_event_time(enqueue_time)
+      perform_at_time = parse_event_time(event.end)
+
+      perform_at_time - enqueue_time
     end
 
     def self.ms2s(milliseconds)
       (milliseconds.to_f / 1000).round(3)
+    end
+
+    def self.parse_event_time(time)
+      case time
+      when Time   then time
+      when String then Time.parse(time).utc
+      else        ::Rails.version >= "7" ? Time.at(time).utc : Time.parse(time.to_s).utc
+      end
     end
   end
 end


### PR DESCRIPTION
Hey! Thanks for the work on this Yabeda plugin 🙏  I'm in the process of bumping one of our apps to Rails edge and ran into an issue with it. 

In Rails 7, `ActiveSupport::Notifications::Event` times (`end`, `time`, `duration`) are in seconds as per https://github.com/rails/rails/pull/50779, which changes all times to be in seconds (done for Rails 7.2 and backported to Rails 7.1 and 7.0). This means that calling `Time.parse(time.to_s).utc` on a seconds value results in an
```
ArgumentError: argument out of range
```

For example:
```ruby
>> Time.at(1710189541.5303319)
=> 2024-03-11 21:39:01 2224373/4194304 +0100
>> Time.parse("1710189541.5303319")
Traceback (most recent call last):
        7: from /Users/rosa/.rbenv/versions/2.7.3/bin/irb:23:in `<main>'
        6: from /Users/rosa/.rbenv/versions/2.7.3/bin/irb:23:in `load'
        5: from /Users/rosa/.rbenv/versions/2.7.3/lib/ruby/gems/2.7.0/gems/irb-1.2.6/exe/irb:11:in `<top (required)>'
        4: from (irb):4
        3: from /Users/rosa/.rbenv/versions/2.7.3/lib/ruby/2.7.0/time.rb:375:in `parse'
        2: from /Users/rosa/.rbenv/versions/2.7.3/lib/ruby/2.7.0/time.rb:266:in `make_time'
        1: from /Users/rosa/.rbenv/versions/2.7.3/lib/ruby/2.7.0/time.rb:266:in `local'
ArgumentError (argument out of range)
```