### PR TITLE
Fix job_latency to work with Rails 7.2

### DIFF
--- a/lib/yabeda/activejob.rb
+++ b/lib/yabeda/activejob.rb
@@ -97,7 +97,7 @@ module Yabeda
       return nil unless enqueue_time.present?
 
       enqueue_time = Time.parse(enqueue_time).utc unless enqueue_time.is_a?(Time)
-      perform_at_time = Time.parse(event.end.to_s).utc
+      perform_at_time = Time.at(event.end).utc
       (perform_at_time - enqueue_time)
     end
 


### PR DESCRIPTION
Time.parse does not work for the unix timestamps (in seconds) now returned by Rails for Event.end.

Fixes: Fullscript/yabeda-activejob#13