### PR TITLE
Fix activejob_latency metric for jobs scheduled to run in the future

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -211,6 +211,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-23
+  arm64-darwin-24
   x86_64-darwin-21
   x86_64-linux
 

--- a/lib/yabeda/activejob.rb
+++ b/lib/yabeda/activejob.rb
@@ -36,7 +36,7 @@ module Yabeda
                             tags: %i[queue activejob executions],
                             buckets: LONG_RUNNING_JOB_RUNTIME_BUCKETS
 
-        histogram :latency, comment: "The job latency, the difference in seconds between enqueued and running time",
+        histogram :latency, comment: "The job latency, the difference in seconds between scheduled and running time",
                             unit: :seconds, per: :activejob,
                             tags: %i[queue activejob executions],
                             buckets: LONG_RUNNING_JOB_RUNTIME_BUCKETS

--- a/lib/yabeda/activejob/event_handler.rb
+++ b/lib/yabeda/activejob/event_handler.rb
@@ -68,13 +68,14 @@ module Yabeda
 
       attr_reader :event
 
-      def job_latency
-        return unless (enqueue_time = event.payload[:job].enqueued_at)
+      def self.job_latency(event)
+        scheduled_time = event.payload[:job].scheduled_at || event.payload[:job].enqueued_at
+        return nil unless scheduled_time.present?
 
-        enqueue_time = parse_event_time(enqueue_time)
+        scheduled_time = parse_event_time(scheduled_time)
         perform_at_time = parse_event_time(event.end)
 
-        perform_at_time - enqueue_time
+        perform_at_time - scheduled_time
       end
 
       def ms2s(milliseconds)

--- a/spec/yabeda/activejob_spec.rb
+++ b/spec/yabeda/activejob_spec.rb
@@ -57,14 +57,31 @@ RSpec.describe Yabeda::ActiveJob, type: :integration do
 
     describe "job latency calculation" do
       # Rails 7.1.4 and above
-      it "measures correct latency from end_time in seconds", queue_adapter: :test do
-        base_time = Time.now
+      it "measures correct latency from end_time in seconds for a job without a wait time", queue_adapter: :test do
+        enqueued_time = Time.now
 
-        # Mock the job's enqueued_at time to be exactly base_time
-        allow_any_instance_of(HelloJob).to receive(:enqueued_at).and_return(base_time) # rubocop:disable RSpec/AnyInstance
+        allow_any_instance_of(HelloJob).to receive(:enqueued_at).and_return(enqueued_time) # rubocop:disable RSpec/AnyInstance
 
         # Mock the event end time to simulate 60 seconds later
-        allow_any_instance_of(ActiveSupport::Notifications::Event).to receive(:end).and_return((base_time + 60.seconds).to_f) # rubocop:disable RSpec/AnyInstance
+        allow_any_instance_of(ActiveSupport::Notifications::Event).to receive(:end).and_return((enqueued_time + 60.seconds).to_f) # rubocop:disable RSpec/AnyInstance
+
+        expect { HelloJob.perform_later }.to have_enqueued_job.on_queue("default")
+        expect { perform_enqueued_jobs }.to measure_yabeda_histogram(Yabeda.activejob.latency)
+          .with_tags(queue: "default", activejob: "HelloJob", executions: "1")
+          .with(be_within(0.1).of(60.0))
+      end
+
+      # Rails 7.1.4 and above
+      it "measures the correct latency from end_time in seconds for job with wait time" do
+        enqueued_time = Time.now
+        wait = 1.minute
+        scheduled_time = enqueued_time + wait
+
+        allow_any_instance_of(HelloJob).to receive(:enqueued_at).and_return(enqueued_time) # rubocop:disable RSpec/AnyInstance
+        allow_any_instance_of(HelloJob).to receive(:scheduled_at).and_return(scheduled_time) # rubocop:disable RSpec/AnyInstance
+
+        # Mock the event end time to simulate 60 seconds later
+        allow_any_instance_of(ActiveSupport::Notifications::Event).to receive(:end).and_return((scheduled_time + 60.seconds).to_f) # rubocop:disable RSpec/AnyInstance
 
         expect { HelloJob.perform_later }.to have_enqueued_job.on_queue("default")
         expect { perform_enqueued_jobs }.to measure_yabeda_histogram(Yabeda.activejob.latency)
@@ -73,14 +90,31 @@ RSpec.describe Yabeda::ActiveJob, type: :integration do
       end
 
       # Rails 7.1.3 and below
-      it "measures correct latency from end_time in milliseconds", queue_adapter: :test do
-        base_time = Time.now
+      it "measures correct latency from end_time in milliseconds for a job without a wait time", queue_adapter: :test do
+        enqueued_time = Time.now
 
-        # Mock the job's enqueued_at time to be exactly base_time
-        allow_any_instance_of(HelloJob).to receive(:enqueued_at).and_return(base_time) # rubocop:disable RSpec/AnyInstance
+        allow_any_instance_of(HelloJob).to receive(:enqueued_at).and_return(enqueued_time) # rubocop:disable RSpec/AnyInstance
 
         # Mock the event end time to simulate 60 seconds later (in milliseconds)
-        allow_any_instance_of(ActiveSupport::Notifications::Event).to receive(:end).and_return((base_time + 60.seconds).to_f * 1000) # rubocop:disable RSpec/AnyInstance
+        allow_any_instance_of(ActiveSupport::Notifications::Event).to receive(:end).and_return((enqueued_time + 60.seconds).to_f * 1000) # rubocop:disable RSpec/AnyInstance
+
+        expect { HelloJob.perform_later }.to have_enqueued_job.on_queue("default")
+        expect { perform_enqueued_jobs }.to measure_yabeda_histogram(Yabeda.activejob.latency)
+          .with_tags(queue: "default", activejob: "HelloJob", executions: "1")
+          .with(be_within(0.1).of(60.0))
+      end
+
+      # Rails 7.1.3 and below
+      it "measures correct latency from end_time in milliseconds for a job with a wait time", queue_adapter: :test do
+        enqueued_time = Time.now
+        wait = 1.minute
+        scheduled_time = enqueued_time + wait
+
+        allow_any_instance_of(HelloJob).to receive(:enqueued_at).and_return(enqueued_time) # rubocop:disable RSpec/AnyInstance
+        allow_any_instance_of(HelloJob).to receive(:scheduled_at).and_return(scheduled_time) # rubocop:disable RSpec/AnyInstance
+
+        # Mock the event end time to simulate 60 seconds later (in milliseconds)
+        allow_any_instance_of(ActiveSupport::Notifications::Event).to receive(:end).and_return((scheduled_time + 60.seconds).to_f * 1000) # rubocop:disable RSpec/AnyInstance
 
         expect { HelloJob.perform_later }.to have_enqueued_job.on_queue("default")
         expect { perform_enqueued_jobs }.to measure_yabeda_histogram(Yabeda.activejob.latency)


### PR DESCRIPTION
- Job latency is now measured as a difference between scheduled and running time.
- Tests are included.

Fix #21

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the `activejob.latency` metric calculation for scheduled jobs by switching the reference timestamp, which can alter reported values and affects instrumentation on job start events. Test coverage is expanded, but metric semantics changes may impact dashboards/alerts.
> 
> **Overview**
> Fixes the `activejob.latency` histogram to measure **scheduled-to-start** delay (uses `scheduled_at` when present, otherwise falls back to `enqueued_at`), and updates the metric description to match.
> 
> Expands specs to validate latency for both immediate and delayed jobs, and for Rails versions emitting `event.end` in either seconds or milliseconds. Also updates `Gemfile.lock` to include the `arm64-darwin-24` platform.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d434cd7198980acdc4a23483a8785b8566e2509e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->