### PR TITLE
Add custom tagging

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,38 @@ end
 
 **Note**: Since the notifications are registered on install make sure to setup your after_event_block before calling install!
 
+## Custom Tags
+
+You can add custom tags to all metrics emitted for a specific job by defining a `yabeda_tags` instance method on your job class. This works similarly to [yabeda-sidekiq's custom tags](https://github.com/yabeda-rb/yabeda-sidekiq#custom-tags).
+
+```ruby
+class ImportJob < ActiveJob::Base
+  def perform(tenant_id, data)
+    # ...
+  end
+
+  def yabeda_tags
+    { tenant: arguments.first }
+  end
+end
+```
+
+The returned hash is merged into every metric's label set for that job (enqueued, executed, success, failed, runtime, latency).
+
+If your `yabeda_tags` method accepts arguments, the job's arguments will be forwarded to it:
+
+```ruby
+class ImportJob < ActiveJob::Base
+  def perform(tenant_id, data)
+    # ...
+  end
+
+  def yabeda_tags(tenant_id, _data)
+    { tenant: tenant_id }
+  end
+end
+```
+
 ## Metrics
 
 - Total enqueued jobs: `activejob.enqueued_total` segmented by: queue, activejob(job class name), executions(number of executions)

--- a/lib/yabeda/activejob.rb
+++ b/lib/yabeda/activejob.rb
@@ -15,6 +15,16 @@ module Yabeda
 
     mattr_accessor :after_event_block, default: proc { |_event| }
 
+    def self.custom_tags(job)
+      return {} unless job.respond_to?(:yabeda_tags)
+
+      if job.method(:yabeda_tags).arity.zero?
+        job.yabeda_tags
+      else
+        job.yabeda_tags(*job.arguments)
+      end
+    end
+
     # rubocop: disable Metrics/MethodLength, Metrics/BlockLength, Metrics/AbcSize
     def self.install!
       Yabeda.configure do

--- a/lib/yabeda/activejob/event_handler.rb
+++ b/lib/yabeda/activejob/event_handler.rb
@@ -96,7 +96,7 @@ module Yabeda
           activejob: job.class.to_s,
           queue: job.queue_name,
           executions: job.executions.to_s,
-        )
+        ).merge(Yabeda::ActiveJob.custom_tags(job))
       end
 
       def call_after_event_block

--- a/lib/yabeda/activejob/event_handler.rb
+++ b/lib/yabeda/activejob/event_handler.rb
@@ -8,11 +8,8 @@ module Yabeda
       end
 
       def handle_perform
-        labels = {
-          activejob: event.payload[:job].class.to_s,
-          queue: event.payload[:job].queue_name.to_s,
-          executions: event.payload[:job].executions.to_s,
-        }
+        labels = common_labels(event.payload[:job])
+
         if event.payload[:exception].present?
           Yabeda.activejob_failed_total.increment(
             labels.merge(failure_reason: event.payload[:exception].first.to_s),

--- a/spec/support/rails_app.rb
+++ b/spec/support/rails_app.rb
@@ -38,6 +38,26 @@ class ErrorLongJob < ActiveJob::Base
   end
 end
 
+class TaggedJob < ActiveJob::Base
+  def perform(tenant_id)
+    puts "Tagged job for #{tenant_id}"
+  end
+
+  def yabeda_tags
+    { tenant: arguments.first }
+  end
+end
+
+class TaggedArgsErrorJob < ActiveJob::Base
+  def perform(tenant_id)
+    raise StandardError
+  end
+
+  def yabeda_tags(tenant_id)
+    { tenant: tenant_id }
+  end
+end
+
 Rails.application = TestApplication
 
 TestApplication.initialize!

--- a/spec/yabeda/activejob_spec.rb
+++ b/spec/yabeda/activejob_spec.rb
@@ -244,4 +244,25 @@ RSpec.describe Yabeda::ActiveJob, type: :integration do
       expect(Yabeda.activejob.scheduled_total.values.values.sum).to eq(jobs_count)
     end
   end
+
+  context "when job defines yabeda_tags" do
+    it "includes zero-arity custom tags in perform metrics" do
+      expect { TaggedJob.perform_later("tenant_1") }.to \
+        increment_yabeda_counter(Yabeda.activejob.success_total)
+        .with_tags(queue: "default", activejob: "TaggedJob", executions: "1", tenant: "tenant_1")
+        .by(1)
+    end
+
+    it "includes argument-forwarded custom tags in failed metrics" do
+      expect { TaggedArgsErrorJob.perform_later("tenant_1") }.to \
+        increment_yabeda_counter(Yabeda.activejob.failed_total)
+        .with_tags(
+          queue: "default",
+          activejob: "TaggedArgsErrorJob",
+          executions: "1",
+          failure_reason: "StandardError",
+          tenant: "tenant_1",
+        ).by(1).and(raise_error(StandardError))
+    end
+  end
 end


### PR DESCRIPTION
* Refactor EventHandler#handle_perform to use #common_labels like the rest of the handlers
* Add support for custom tagging similar to what [yabeda-sidekiq](https://github.com/yabeda-rb/yabeda-sidekiq/blob/master/lib/yabeda/sidekiq.rb#L125-L129) does and write tests for this functionality
* Document this behavior in the README

Hello, I'm a Red Hat dev of [Insights Compliance](https://github.com/RedHatInsights/compliance-backend) and we're recently trying to [move away from Sidekiq](https://github.com/RedHatInsights/compliance-backend/pull/2672). 
We'd like to retain the [custom tagging](https://github.com/RedHatInsights/compliance-backend/blob/bd1ac1acfb3da3e2aa54c1a08c174b42adc1a1c0/app/jobs/parse_report_job.rb#L9-L11) that helps us filter out the jobs run by our QE. I hope the PR is all right and I'm looking forward to your review! :)